### PR TITLE
add charset attribute to white list

### DIFF
--- a/lib/attributes.js
+++ b/lib/attributes.js
@@ -13,6 +13,7 @@ module.exports = [
   "autoPlay",
   "cellPadding",
   "cellSpacing",
+  "charset",
   "checked",
   "class",
   "className",


### PR DESCRIPTION
I’ve added `charset` to the white list because it’s a valid HTML5 dom attribute on meta elements.
