### PR TITLE
Fix script text encoding for vdom ^1.3.0

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -110,7 +110,7 @@ module.exports = function stringify (node, parent, options) {
     }
   }
   else if (isVText(node)) {
-    if (parent && parent.tagName === 'script') {
+    if (parent && parent.tagName.toLowerCase() === 'script') {
       html.push(String(node.text));
     } else {
       html.push(encode(String(node.text)));

--- a/test/stringify.js
+++ b/test/stringify.js
@@ -100,8 +100,8 @@ describe('stringify()', function() {
   });
 
   it('does not encode script tag contents', function() {
-    var vnode = new VirtualNode('div', null, [
-      new VirtualNode('script', null, [new VirtualText('console.log("foobar");')])
+    var vnode = h('div', [
+      h('script', 'console.log("foobar");')
     ]);
     var html = stringify(vnode);
     expect(html).to.be.a('string');


### PR DESCRIPTION
This commit:
https://github.com/Matt-Esch/virtual-dom/commit/e21dc39f1677382bd4a5a651a96ca9ebd51c5646

Made a change so that tagNames are by default capitalized when using
`h`. Because of this and stringify not lower-casing the tagName, there
was a bug causing script texts to be encoded. This fixes it by
lower-casing the tagname before checking. Fixes #19